### PR TITLE
Preparation of CT and ROI meshes in .obj format

### DIFF
--- a/src/RadiotherapyPlansBackend.jl
+++ b/src/RadiotherapyPlansBackend.jl
@@ -6,6 +6,7 @@ using ImageFiltering
 using Makie
 using LinearAlgebra
 using Meshing
+using MeshIO
 using GeometryBasics
 using StaticArrays
 using GLMakie
@@ -157,11 +158,6 @@ function extract_roi_masks(dcm_ct, dcm_rs)
     return roi_to_mask
 end
 
-function sanitize_fname(fname)
-    return replace(fname, r"[%]|[/]" => "_")
-end
-
-
 function make_normals(doses, algo, origin, widths)
     mc = GeometryBasics.Mesh(doses, algo; origin = origin, widths = widths)
     itp = Interpolations.scale(interpolate(doses, BSpline(Quadratic(Periodic(OnGrid())))),
@@ -200,7 +196,20 @@ function ct_origin_widths(ct_files)
     return origin, widths
 end
 
-function make_CT_mesh(ct_files, isolevel::Float64=1200.0; body_mask=nothing)
+"""
+    make_CT_mesh(ct_files, isolevel::Float64=1200.0; body_mask=nothing)
+
+Make a mesh representing the given isolevel of a CT image given in `ct_files`. The argument
+`ct_files` can be taken from `DoseData`.
+
+# Arguments
+
+* `isolevel` should be specified in [Hounsfield scale](https://en.wikipedia.org/wiki/Hounsfield_scale).
+* `body_mask` can be `nothing` (and then it does nothing) or a 3D boolean array of the same
+    size as CT pixel array. If specified, the CT images is trimmed to `true` values in the
+    given array.
+"""
+function make_CT_mesh(ct_files; isolevel::Float64=1200.0, body_mask=nothing)
     algo_ct = NaiveSurfaceNets(iso=isolevel, insidepositive=true)
     px_data = copy(ct_files[1].pixeldata)
     origin, widths = ct_origin_widths(ct_files)
@@ -327,10 +336,39 @@ hnscc_7 = load_DICOMs(
     HNSCC_BASE_PATH * "HNSCC-01-0007/04-29-1997-RT SIMULATION-32176/1.000000-06686/1-1.dcm",
 )
 
-function ct_mesh_from_files(ct_fname)
-    ct_files = load_dicom(ct_fname)
-    return make_CT_mesh(ct_files)
+"""
+    ct_mesh_from_files(dd::DoseData, ct_mesh_fname; kwargs...)
+
+Make a CT mesh from the given `DoseData` object and save the result to file `ct_mesh_fname`.
+The extension part of `ct_mesh_fname` file must be one of the formats supported by MeshIO.
+`.obj` is preferred.
+
+Given `kwargs` are passed to `make_CT_mesh`.
+
+# Example
+
+`ct_mesh_from_files(dd, "/tmp/test.obj"; isolevel=1000.0)`
+"""
+function ct_mesh_from_files(dd::DoseData, ct_mesh_fname; kwargs...)
+    ct_mesh = make_CT_mesh(dd.ct_files; kwargs...)
+    save(ct_mesh_fname, ct_mesh)
+    return ct_mesh_fname
 end
+
+"""
+    make_ROI_mesh(dd::DoseData, roi_name, roi_mesh_fname)
+
+Prepare mesh of ROI boundary for for the region of name `roi_name`. The mesh is saved in
+file `roi_mesh_fname`.
+"""
+function make_ROI_mesh(dd::DoseData, roi_name, roi_mesh_fname)
+    algo_roi = NaiveSurfaceNets(iso=0.5, insidepositive=true)
+    origin, widths = ct_origin_widths(dd.ct_files)
+    roi_mesh = make_normals(convert(Array{Float32}, dd.roi_masks[roi_name]), algo_roi, origin, widths)
+    save(roi_mesh_fname, roi_mesh)
+    return roi_mesh_fname
+end
+
 
 """
     test_scene()


### PR DESCRIPTION
This PR provides two function for making meshes from CT images (`ct_mesh_from_files`) and ROIs (`make_ROI_mesh`) based on loaded DICOM files, passed as the first argument. This argument is a temporary solution, ultimately this is supposed to be stored globally by the script.